### PR TITLE
Do not trigger click event on touch devices

### DIFF
--- a/shower-touch.js
+++ b/shower-touch.js
@@ -76,6 +76,7 @@ shower.modules.define('shower-touch', [
 
             if (slide) {
                 if (isSlideMode && !this._isInteractiveElement(element)) {
+                    e.preventDefault();
                     x = e.touches[0].pageX;
                     if (x > window.innerWidth / 2) {
                         shower.player.next();


### PR DESCRIPTION
A ghost click would be triggered after the touch event, resulting in a flickering after every tap on iOS devices.
